### PR TITLE
Refactor(user): Replace generic update endpoint with dedicated update role endpoint

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -8,7 +8,6 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
-import { User } from './entities/user.entity';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Roles } from '../common/decorators/roles.decorator';
 import { JwtAuthGuard } from 'src/auth/guard/jwt.guard';
@@ -31,10 +30,13 @@ export class UsersController {
     return this.usersService.findOne(id);
   }
 
-  @Patch(':id')
+  @Patch(':id/role')
   @Roles(RolesEnum.ADMIN)
-  update(@Param('id') id: string, @Body() updateDto: Partial<User>) {
-    return this.usersService.update(id, updateDto);
+  updateUserRole(
+    @Param('id') id: string,
+    @Body() updateDto: { role: RolesEnum },
+  ) {
+    return this.usersService.updateUserRole(id, updateDto.role);
   }
 
   @Delete(':id')

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,8 +1,9 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { RegisterDto } from '../auth/dto/register.dto';
+import { RolesEnum } from 'src/common/enum/roles.enum';
 @Injectable()
 export class UsersService {
   constructor(
@@ -29,9 +30,15 @@ export class UsersService {
     return this.usersRepository.findOneBy({ email });
   }
 
-  async update(id: string, updateDto: Partial<User>): Promise<User> {
-    const userToUpdate = await this.findOne(id);
-    return this.usersRepository.save({ ...userToUpdate, ...updateDto });
+  async updateUserRole(id: string, role: RolesEnum): Promise<User> {
+    const user = await this.usersRepository.findOne({ where: { id } });
+
+    if (!user) {
+      throw new NotFoundException(`User with ID ${id} not found`);
+    }
+
+    user.role = role;
+    return this.usersRepository.save(user);
   }
 
   async remove(id: string): Promise<void> {


### PR DESCRIPTION
## Description  
This PR removes the generic update endpoint that allowed modifying multiple user fields and introduces a dedicated endpoint for updating a user's role. The changes include:  
- Removing the broad `PATCH /users/:id` endpoint.  
- Adding a dedicated `PATCH /users/:id/role` endpoint restricted to Admins for managing user roles only.  
- Updating the UsersService to fetch and return the updated user after modifying the role.

## Changes  
- Removed the generic update endpoint.  
- Implemented the `updateUserRole` method in UsersService using `update()` followed by a `findOne()` call (or alternatively using `save()`).  
- Ensured that only Admins can update the user role via the dedicated endpoint.

## Checklist  
- [x] Endpoint now strictly handles role updates.  
- [x] Updated UsersService returns the updated user entity.  
- [x] Role management functionality tested and verified.