### PR TITLE
Added Seed Script to Populate realistic data to Database

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "zod": "^3.24.2"
       },
       "devDependencies": {
+        "@faker-js/faker": "^9.6.0",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^11.0.12",
@@ -1789,6 +1790,23 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.6.0.tgz",
+      "integrity": "sha512-3vm4by+B5lvsFPSyep3ELWmZfE3kicDtmemVpuwl1yH7tqtnHdsA6hG8fbXedMVdkzgtvzWoRgjSB4Q+FHnZiw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "migration:generate": "typeorm migration:generate -d src/data-source.ts -n",
     "migration:run": "typeorm migration:run -d src/data-source.ts",
     "migration:revert": "typeorm migration:revert -d src/data-source.ts",
-    "migration:show": "typeorm migration:show -d src/data-source.ts"
+    "migration:show": "typeorm migration:show -d src/data-source.ts",
+    "seed": "cross-env NODE_ENV=local ts-node ./src/seed.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.777.0",
@@ -51,6 +52,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.6.0",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^11.0.12",

--- a/src/common/postgres/data.source.ts
+++ b/src/common/postgres/data.source.ts
@@ -1,5 +1,7 @@
 import { DataSource, DataSourceOptions } from 'typeorm';
 import * as dotenv from 'dotenv-flow';
+import { User } from '../../users/entities/user.entity';
+import { Documents } from '../../documents/entities/documents.entity';
 dotenv.config({ silent: true });
 
 export const dbdatasource: DataSourceOptions = {
@@ -9,8 +11,8 @@ export const dbdatasource: DataSourceOptions = {
   username: process.env.PG_USER,
   password: process.env.PG_PASSWORD,
   database: process.env.PG_DATABASE,
-  synchronize: false,
-  entities: [],
+  synchronize: process.env.NODE_ENV === 'local' ? true : false,
+  entities: [User, Documents],
   migrations: ['dist/common/postgres/migrations/*.js'],
 };
 

--- a/src/seed.ts
+++ b/src/seed.ts
@@ -1,0 +1,75 @@
+import { DataSource } from 'typeorm';
+
+import * as bcrypt from 'bcrypt';
+import { v4 as uuidv4 } from 'uuid';
+import { faker } from '@faker-js/faker';
+import { Documents } from './documents/entities/documents.entity';
+import { User } from './users/entities/user.entity';
+import { RolesEnum } from './common/enum/roles.enum';
+import { DocumentStatusEnum } from './documents/enum/document.status';
+import dataSource from './common/postgres/data.source';
+async function seedDatabase(dataSource: DataSource) {
+  const userRepository = dataSource.getRepository(User);
+  const documentRepository = dataSource.getRepository(Documents);
+
+  const saltRounds = 10;
+
+  const usersData = [
+    { email: 'admin@example.com', role: RolesEnum.ADMIN },
+    { email: 'editor@example.com', role: RolesEnum.EDITOR },
+    { email: 'viewer1@example.com', role: RolesEnum.VIEWER },
+    { email: 'viewer2@example.com', role: RolesEnum.VIEWER },
+    { email: 'editor2@example.com', role: RolesEnum.EDITOR },
+  ];
+
+  const createdUsers: User[] = [];
+
+  for (const userData of usersData) {
+    const hashedPassword = await bcrypt.hash(userData.email, saltRounds);
+    const user = userRepository.create({
+      id: uuidv4(),
+      email: userData.email,
+      password: hashedPassword,
+      role: userData.role,
+    });
+    const savedUser = await userRepository.save(user);
+    createdUsers.push(savedUser);
+  }
+
+  const documentsData = [];
+  for (let i = 0; i < 20; i++) {
+    documentsData.push({
+      id: uuidv4(),
+      title: faker.lorem.sentence(),
+      uploadedBy:
+        createdUsers[Math.floor(Math.random() * createdUsers.length)].id,
+      url: faker.internet.url(),
+      status: faker.helpers.enumValue(DocumentStatusEnum),
+    });
+  }
+
+  for (const documentData of documentsData) {
+    const document = documentRepository.create(documentData);
+    await documentRepository.save(document);
+  }
+
+  console.log('Database seeded successfully.');
+}
+
+export async function runSeed(dataSource: DataSource) {
+  try {
+    await seedDatabase(dataSource);
+  } catch (error) {
+    console.error('Error seeding database:', error);
+  }
+}
+
+dataSource
+  .initialize()
+  .then(async () => {
+    await runSeed(dataSource);
+    await dataSource.destroy();
+  })
+  .catch((error) => {
+    console.error('Error initializing data source:', error);
+  });


### PR DESCRIPTION
## Description

This pull request implements a database seeding script that uses Faker and UUIDs to generate realistic test data. It addresses the issue of missing entity metadata during the seeding process by ensuring the `DataSource` is fully initialized before attempting to seed the database.

**Key Changes:**

* **UUID Generation:** Uses `uuid` to generate unique IDs for users and documents.
* **Faker Data Generation:** Leverages `@faker-js/faker` to create realistic document titles, URLs, and statuses.
* **Asynchronous `DataSource` Initialization:** Waits for the `DataSource` to be fully initialized before executing the seeding script.
* **Connection Closure:** Closes the database connection after seeding to free up resources.
* **Environment Variable:** Uses `NODE_ENV=local` to run the seed script.
* **Error Handling:** Added try/catch blocks to enhance error catching.
* **Entity import correction:** Corrected the path to the user entity.

**Benefits:**

* Provides a more robust and realistic way to seed the database for development and testing.
* Ensures that the seeding process is reliable and avoids metadata errors.
* Improves the developer experience by simplifying the creation of test data.

## Checklist

-   [x] Code follows project coding standards.
-   [x] All new and existing tests pass.
-   [x] Changes have been thoroughly tested.

## How to Test

1.  Run `npm install` 
2.  Run `npm run seed` to execute the seeding script.
3.  Verify that the database is populated with realistic test data.