### PR TITLE
feat(documents): add user-based querying, pre-signed URLs & metaInfo schema update

### DIFF
--- a/src/common/aws/aws.service.ts
+++ b/src/common/aws/aws.service.ts
@@ -22,19 +22,34 @@ export class AwsService {
 
   async generatePreSignedUrl(
     fileName: string,
-    fileType: string,
+    mimeType: string,
   ): Promise<string> {
     const key = `documents/${uuid()}-${fileName}`;
 
     const command = new PutObjectCommand({
       Bucket: this.S3Config.bucketName,
       Key: key,
-      ContentType: fileType,
+      ContentType: mimeType,
     });
 
     const url = getSignedUrl(this.s3, command, { expiresIn: 3600 });
 
     return url;
+  }
+
+  async generatePreSignedUrlForExistingFile(
+    url: string,
+    mimeType: string,
+  ): Promise<string> {
+    const { bucketName } = this.S3Config;
+    const fileKey = this.extractFileKeyFromUrl(url, bucketName);
+    const command = new PutObjectCommand({
+      Bucket: bucketName,
+      Key: fileKey,
+      ContentType: mimeType,
+    });
+    const newUrl = getSignedUrl(this.s3, command, { expiresIn: 3600 });
+    return newUrl;
   }
 
   async uploadToS3(file: Express.Multer.File) {

--- a/src/documents/documents.service.ts
+++ b/src/documents/documents.service.ts
@@ -13,6 +13,11 @@ import { DocumentCreateDto } from './dto/document.create';
 import { lastValueFrom } from 'rxjs';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
+import {
+  PaginatedResponseDto,
+  PaginationMetaDto,
+} from 'src/common/dto/paginated-resonse.dto';
+import { PaginationDto } from 'src/common/dto/pagination.dto';
 @Injectable()
 export class DocumentsService {
   ingestionServiceUrl: string;
@@ -44,6 +49,13 @@ export class DocumentsService {
       uploadedBy: user.id,
       title,
       url: fileUrl,
+      metaInfo: {
+        originalName: file.originalname,
+        mimeType: file.mimetype,
+        size: file.size,
+        encoding: file.encoding,
+        fieldName: file.fieldname,
+      },
       status: DocumentStatusEnum.UPLOADED,
     });
 
@@ -60,18 +72,37 @@ export class DocumentsService {
       uploadedBy: user.id,
       title: dto.title,
       url: dto.url,
+      metaInfo: dto.metaInfo,
       status: DocumentStatusEnum.UPLOADED,
     });
   }
+
   async getPresignedUrl(fileName: string, fileType: string) {
     return this.awsService.generatePreSignedUrl(fileName, fileType);
   }
 
-  async findAll(uploadedBy: string) {
-    console.log('uploadedBy', uploadedBy);
-    return await this.documentsRepository.find({
-      where: { uploadedBy },
+  async findAll(
+    uploadedBy: string,
+    paginationDto: PaginationDto,
+  ): Promise<PaginatedResponseDto<Documents>> {
+    const { page, limit, orderBy } = paginationDto;
+    const skip = (page - 1) * limit;
+    const [items, totalItems] = await this.documentsRepository
+      .createQueryBuilder('documents')
+      .where('documents.uploadedBy= :uploadedBy', { uploadedBy })
+      .orderBy('documents.createdAt', orderBy)
+      .skip(skip)
+      .take(limit)
+      .getManyAndCount();
+    const meta = new PaginationMetaDto({
+      page,
+      limit,
+      totalItems,
     });
+    return {
+      items,
+      meta,
+    };
   }
 
   async findOne(id: string) {
@@ -107,11 +138,17 @@ export class DocumentsService {
       throw new BadRequestException('Document is not created By User');
     }
 
+    const preSignedUrl =
+      await this.awsService.generatePreSignedUrlForExistingFile(
+        document.url,
+        document.metaInfo.mimeType,
+      );
+
     try {
       await lastValueFrom(
         this.httpService.post(this.ingestionServiceUrl, {
           documentId,
-          fileUrl: document.url,
+          fileUrl: preSignedUrl,
         }),
       );
 

--- a/src/documents/dto/document.create.ts
+++ b/src/documents/dto/document.create.ts
@@ -1,5 +1,32 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+export class FileMetaInfoDto {
+  @ApiProperty({ example: 'resume.pdf' })
+  @IsString()
+  @Transform(({ value }) => value ?? 'unknown.pdf')
+  originalName: string;
+
+  @ApiProperty({ example: 'application/pdf' })
+  @IsString()
+  @Transform(({ value }) => value ?? 'application/octet-stream')
+  mimeType: string;
+
+  @ApiProperty({ example: 204800 }) // 200 KB
+  @IsNumber()
+  @Transform(({ value }) => value ?? 0)
+  size: number;
+
+  @ApiProperty({ example: '7bit' })
+  @IsString()
+  @Transform(({ value }) => value ?? '7bit')
+  encoding: string;
+
+  @ApiProperty({ example: 'file' })
+  @IsString()
+  @Transform(({ value }) => value ?? 'file')
+  fieldName: string;
+}
 
 export class DocumentCreateDto {
   @ApiProperty({
@@ -9,6 +36,11 @@ export class DocumentCreateDto {
   @IsNotEmpty()
   title: string;
 
+  @ApiProperty({
+    type: FileMetaInfoDto,
+    description: 'Information about the Document',
+  })
+  metaInfo: FileMetaInfoDto;
   @ApiProperty({
     example: 'https://example.com/document.pdf',
     description: 'URL of the document',

--- a/src/documents/entities/documents.entity.ts
+++ b/src/documents/entities/documents.entity.ts
@@ -6,6 +6,7 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 import { DocumentStatusEnum } from '../enum/document.status';
+import { IFileMetaInfo } from '../interface';
 @Entity()
 export class Documents {
   @PrimaryGeneratedColumn('uuid')
@@ -22,6 +23,9 @@ export class Documents {
 
   @Column({ enum: DocumentStatusEnum })
   status: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metaInfo: IFileMetaInfo;
 
   @CreateDateColumn({
     type: 'timestamp',

--- a/src/documents/interface/index.ts
+++ b/src/documents/interface/index.ts
@@ -1,0 +1,7 @@
+export interface IFileMetaInfo {
+  originalName: string;
+  mimeType: string;
+  size: number;
+  encoding: string;
+  fieldName: string;
+}


### PR DESCRIPTION
## ✨ What’s New

- Updated `findByUser` (admin) and `findMyDocuments` (self) endpoints for retrieving documents with pagination support.
- Added AWS S3 pre-signed URL generation for secure access to existing document files.
- **Updated Schema**: Refactored the `metaInfo` column in the `Documents` entity to use the `jsonb` type with a strongly typed `IFileMetaInfo` interface.

## 📦 Schema Changes

- `Documents.metaInfo` now stores structured file metadata like:
  - `originalName`
  - `mimeType`
  - `size`
  - `encoding`
  - `fieldName`

> 🧠 Important: Make sure to run the latest DB migrations and verify that existing records align with the new `metaInfo` structure.

## ✅ How to Test

- Upload a document using the `/upload` endpoint.
- Verify the metadata structure stored in DB.
- Fetch documents with `/find_by_user/:userId` (admin) and `/find_my_documents` (auth user).
- Validate that S3 pre-signed URLs are generated and accessible for existing files.

## 🛡️ Access Control

- Admin-only route: `findByUser`
- Authenticated user route: `findMyDocuments`

---

Let me know if you'd like to include screenshots or Swagger JSON examples.
