### PR TITLE
feat(tests): add unit tests for paginated document retrieval

### DIFF
--- a/src/documents/documents.controller.ts
+++ b/src/documents/documents.controller.ts
@@ -26,10 +26,10 @@ import {
   ApiResponse,
   ApiTags,
 } from '@nestjs/swagger';
-import { CurrentUser } from 'src/common/decorators/current-user.decorator';
-import { PaginatedResponseDto } from 'src/common/dto/paginated-resonse.dto';
-import { PaginationDto } from 'src/common/dto/pagination.dto';
-import { User } from 'src/users/entities/user.entity';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { PaginatedResponseDto } from '../common/dto/paginated-resonse.dto';
+import { PaginationDto } from '../common/dto/pagination.dto';
+import { User } from '../users/entities/user.entity';
 
 @ApiTags('Documents')
 @ApiBearerAuth()

--- a/src/documents/documents.service.ts
+++ b/src/documents/documents.service.ts
@@ -16,8 +16,8 @@ import { ConfigService } from '@nestjs/config';
 import {
   PaginatedResponseDto,
   PaginationMetaDto,
-} from 'src/common/dto/paginated-resonse.dto';
-import { PaginationDto } from 'src/common/dto/pagination.dto';
+} from '../common/dto/paginated-resonse.dto';
+import { PaginationDto } from '../common/dto/pagination.dto';
 @Injectable()
 export class DocumentsService {
   ingestionServiceUrl: string;

--- a/src/documents/dto/document.create.ts
+++ b/src/documents/dto/document.create.ts
@@ -41,6 +41,7 @@ export class DocumentCreateDto {
     description: 'Information about the Document',
   })
   metaInfo: FileMetaInfoDto;
+
   @ApiProperty({
     example: 'https://example.com/document.pdf',
     description: 'URL of the document',

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -14,7 +14,7 @@ import { Roles } from '../common/decorators/roles.decorator';
 import { JwtAuthGuard } from '../auth/guard/jwt.guard';
 import { RolesEnum } from '../common/enum/roles.enum';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
-import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { PaginationDto } from '../common/dto/pagination.dto';
 
 @ApiTags('Users')
 @ApiBearerAuth()

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,11 +4,11 @@ import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { RegisterDto } from '../auth/dto/register.dto';
 import { RolesEnum } from '../common/enum/roles.enum';
-import { PaginationDto } from 'src/common/dto/pagination.dto';
+import { PaginationDto } from '../common/dto/pagination.dto';
 import {
   PaginatedResponseDto,
   PaginationMetaDto,
-} from 'src/common/dto/paginated-resonse.dto';
+} from '../common/dto/paginated-resonse.dto';
 @Injectable()
 export class UsersService {
   constructor(


### PR DESCRIPTION
### 📌 What’s Changed

- Added unit tests for `DocumentsService.findAll()` method
- Mocked `createQueryBuilder` to simulate paginated document retrieval
- Verified returned pagination metadata and items count

### ✅ Improvements

- Improves test coverage for the document service
- Ensures pagination logic works as expected with mocked data

### 🧪 Tests

- Covers pagination metadata calculation
- Validates `items` length and query builder calls


